### PR TITLE
(#2) - fix call stack exceeded in pouch v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ staticSecurityWrappers.destroy = requiresServerAdmin;
 staticSecurityWrappers.replicate = function (original, args) {
   //emulate replicate.to/replicate.from
   var PouchDB = args.base;
-  args.db = new PouchDB(args.source);
+  args.db = args.source instanceof PouchDB ? args.source : new PouchDB(args.source);
   //and call its handler
   var handler = securityWrappers['replicate.to'];
   return handler(original, args);


### PR DESCRIPTION
This fixes the issue for me; may need tests for weird edge
cases like one db is PouchDB and the other is a PouchDB.defaults()
variant.
